### PR TITLE
Fix detection of the stage3 tarball location

### DIFF
--- a/modules/config.sh
+++ b/modules/config.sh
@@ -240,7 +240,7 @@ stage_latest() {
     esac
     if [ -n "${stage_arch}" ]; then
         local distfiles_base="http://distfiles.gentoo.org/releases/${stage_mainarch}/autobuilds"
-        local latest_stage=$(wget -qO- ${distfiles_base}/latest-stage3-${stage_arch}.txt | egrep "stage3-${stage_arch}.*[0-9]{8}" )
+        local latest_stage=$(wget -qO- ${distfiles_base}/latest-stage3.txt | egrep "stage3-${stage_arch}.*[0-9]{8}" )
         [ -z "${latest_stage}" ] && die "Cannot find the relevant stage tarball, use stage_uri in your profile instead"
         if [ -n "${latest_stage}" ]; then
             stage_uri="${distfiles_base}/${latest_stage}"


### PR DESCRIPTION
Looks like https://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64.txt only contains stage3 for hardened whereas https://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3.txt contains the stage3 location for default amd64.
