### PR TITLE
Sleep between fdisk runs

### DIFF
--- a/modules/partition.sh
+++ b/modules/partition.sh
@@ -82,6 +82,7 @@ sfdisk_command() {
     # hdparm -z force really works partprobe not
     debug sfdisk_command "running sfdisk partitions '${partitions}' on device ${device} with geometry ${geometry_args}"
     spawn "echo -e '${partitions}' | sfdisk -uM ${geometry_args} ${device}" && spawn "hdparm -z ${device}" && \
+    sleep 1 && \
     # NOTE fix 2048 missing space before first partition, gosh I've chased this one...
     debug sfdisk_command "running fdisk pad 2048 before the first partition" && \
     spawn "( echo x; echo b; echo 1; echo 2048; echo r; echo w ) | fdisk ${device}" # || die "cannot pad 2048 space before first partition (needed for grub:2)"


### PR DESCRIPTION
On a VMWare Workstation VM doing fdisk back to back results in a "device
busy" error. Putting a sleep between fdisk calls lets it succeed.
